### PR TITLE
Added index for lists

### DIFF
--- a/fortnite_to_influx.py
+++ b/fortnite_to_influx.py
@@ -107,6 +107,10 @@ def flatten_stats(stats):
         if isinstance(obj, dict):
             for k, v in obj.items():
                 _flatten(v, f"{prefix}{k}_")
+        elif isinstance(obj, list):
+            for idx, item in enumerate(obj):
+                # Use index in key to preserve all array elements
+                _flatten(item, f"{prefix}{idx}_")
         else:
             flat[prefix[:-1]] = obj
     _flatten(stats)


### PR DESCRIPTION
# Pull Request

## Description

The flatten_stats function now preserves arrays (like accountLevelHistory) by flattening each element with its index in the key. This ensures no data is lost when writing to InfluxDB. All nested lists and objects will be included in the flattened output.

## Types of changes

What types of changes does your change introduce?</br>
_Please put an `x` in the boxes that apply_

- [ ] New feature (adds functionality)
- [x] Bugfix (fixes an issue)
- [ ] Security (fixes a security issue) | Please have a look at our [Security Policy](../docs/SECURITY.md) first.
- [ ] Code style cleaning or Refactoring (formatting, renaming, restructuring, etc.)
- [ ] Documentation Update
- [ ] Other (please describe):

## Breaking changes

Does this Pull Request cause existing functionality to not work as expected or even break.</br>
_Put an `x` in the boxes that apply_

- [ ] Yes
- [x] No